### PR TITLE
add missing CSS vars

### DIFF
--- a/pdf.js.viewer.css
+++ b/pdf.js.viewer.css
@@ -622,4 +622,6 @@ We'll need to ensure that these two new CSS variables are defined
 .page {
   --user-unit:1;
   --total-scale-factor:calc(var(--scale-factor) * var(--user-unit));
+  --scale-round-x: 1px;
+  --scale-round-y: 1px;
 }


### PR DESCRIPTION
Sorry about this: turns out there's something I missed. The container needs these CSS vars or else the annotation layer disappears when you resize the page in Chromium browsers